### PR TITLE
後押しキーの入力優先

### DIFF
--- a/Classes/Character.h
+++ b/Classes/Character.h
@@ -3,6 +3,8 @@
 
 #include "cocos2d.h" 
 
+USING_NS_CC;
+
 enum class AnimState {
     Idle,
     Walk,
@@ -14,6 +16,7 @@ struct CharacterInput {
     bool left = false;
     bool right = false;
     bool up = false;
+    bool down = false;
     bool jump = false;
 };
 
@@ -27,7 +30,7 @@ public:
     virtual bool init(cocos2d::Vec2, std::string);
 
 
-    void update(float, const CharacterInput&);
+    void update(float, const CharacterInput&, const std::vector<EventKeyboard::KeyCode>&);
 
     void onGround();
     void onHitLeft();

--- a/Classes/GameLayer.cpp
+++ b/Classes/GameLayer.cpp
@@ -265,16 +265,28 @@ bool GameLayer::init(int stageNumber) {
     //キー入力listener↓
     auto listener = EventListenerKeyboard::create();
     listener->onKeyPressed = [&](EventKeyboard::KeyCode keyCode, Event* event) { //[]はラムダ式(無名関数)
-        if (keyCode == EventKeyboard::KeyCode::KEY_LEFT_ARROW)
+        if (keyCode == EventKeyboard::KeyCode::KEY_LEFT_ARROW) {
             _leftPressed = true;
-        if (keyCode == EventKeyboard::KeyCode::KEY_RIGHT_ARROW)
+            _currentKey.push_back(keyCode);
+        }
+        if (keyCode == EventKeyboard::KeyCode::KEY_RIGHT_ARROW) {
             _rightPressed = true;
-        if (keyCode == EventKeyboard::KeyCode::KEY_UP_ARROW)
+            _currentKey.push_back(keyCode);
+        }
+        if (keyCode == EventKeyboard::KeyCode::KEY_UP_ARROW) {
             _upPressed = true;
-        if (keyCode == EventKeyboard::KeyCode::KEY_SPACE)
-            if(_chara->canJump())
+            _currentKey.push_back(keyCode);
+        }
+        if (keyCode == EventKeyboard::KeyCode::KEY_DOWN_ARROW) {    //ほかの矢印キーと重ねて押したときにジャンプできない不具合修正のため
+            _downPressed = true;
+        }
+        if (keyCode == EventKeyboard::KeyCode::KEY_SPACE) {
+            if (_chara->canJump()) {
                 _jumpPressed = true;
-        };
+            }
+        }
+        /*_currentKey.push_back(keyCode);*/
+    };
 
 
     listener->onKeyReleased = [&](EventKeyboard::KeyCode keyCode, Event* event) {
@@ -284,7 +296,14 @@ bool GameLayer::init(int stageNumber) {
             _rightPressed = false;
         if (keyCode == EventKeyboard::KeyCode::KEY_UP_ARROW)
             _upPressed = false;
-        };
+        if (keyCode == EventKeyboard::KeyCode::KEY_DOWN_ARROW)
+            _downPressed = false;
+
+        auto it = std::find(_currentKey.begin(), _currentKey.end(), keyCode);
+        if (it != _currentKey.end())
+            _currentKey.erase(it);
+
+    };
 
     _eventDispatcher->addEventListenerWithSceneGraphPriority(listener, this);
 
@@ -393,8 +412,9 @@ void GameLayer::update(float dt){
     input.right = _rightPressed;
     input.jump = _jumpPressed;
     input.up = _upPressed;
+    input.down = _downPressed;
 
-    _chara->update(dt, input);
+    _chara->update(dt, input, _currentKey);
     _jumpPressed = false;
 
     float screenHalf = Director::getInstance()->getVisibleSize().width * 0.5f;

--- a/Classes/GameLayer.h
+++ b/Classes/GameLayer.h
@@ -36,6 +36,9 @@ public:
 
     GoalFlag* _flag;
 
+    /*EventKeyboard::KeyCode _currentKey = EventKeyboard::KeyCode::KEY_NONE;*/
+    std::vector<EventKeyboard::KeyCode> _currentKey;
+
 private:
 
     int _stageNumber;
@@ -45,6 +48,7 @@ private:
     bool _leftPressed = false;
     bool _rightPressed = false;
     bool _upPressed = false;
+    bool _downPressed = false;
     bool _jumpPressed = false;
 
     bool _switchPressed = false;


### PR DESCRIPTION
・vectorで入力を読み取ることにより、重ねてキーを押されたときに後に押されたキーの動作を優先的に実行するように実装
・その他入力による動作の調整（まだ不具合あり）