### PR TITLE
GameLayerメンバノードの複数管理

### DIFF
--- a/Classes/CMakeLists.txt
+++ b/Classes/CMakeLists.txt
@@ -1,0 +1,159 @@
+#/****************************************************************************
+# Copyright (c) 2013-2014 cocos2d-x.org
+# Copyright (c) 2015-2017 Chukong Technologies Inc.
+#
+# http://www.cocos2d-x.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ****************************************************************************/
+
+cmake_minimum_required(VERSION 3.6)
+
+set(APP_NAME game)
+
+project(${APP_NAME})
+
+if(XCODE)
+    if(NOT DEFINED CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET)
+        SET (CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 8.0)
+    endif()
+endif()
+
+if(NOT DEFINED BUILD_ENGINE_DONE) # to test game into root project
+    set(COCOS2DX_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cocos2d)
+    set(CMAKE_MODULE_PATH ${COCOS2DX_ROOT_PATH}/cmake/Modules/)
+
+    include(CocosBuildSet)
+    add_subdirectory(${COCOS2DX_ROOT_PATH}/cocos ${ENGINE_BINARY_PATH}/cocos/core)
+endif()
+
+# record sources, headers, resources...
+set(GAME_SOURCE)
+set(GAME_HEADER)
+
+set(GAME_RES_FOLDER
+    "${CMAKE_CURRENT_SOURCE_DIR}/Resources"
+    )
+if(APPLE OR WINDOWS)
+    cocos_mark_multi_resources(common_res_files RES_TO "Resources" FOLDERS ${GAME_RES_FOLDER})
+endif()
+
+# add cross-platforms source files and header files 
+list(APPEND GAME_SOURCE
+     Classes/AppDelegate.cpp
+     Classes/HelloWorldScene.cpp
+     )
+list(APPEND GAME_HEADER
+     Classes/AppDelegate.h
+     Classes/HelloWorldScene.h
+     )
+
+if(ANDROID)
+    # change APP_NAME to the share library name for Android, it's value depend on AndroidManifest.xml
+    set(APP_NAME MyGame)
+    list(APPEND GAME_SOURCE
+         proj.android/app/jni/hellocpp/main.cpp
+         )
+elseif(LINUX)
+    list(APPEND GAME_SOURCE
+         proj.linux/main.cpp
+         )
+elseif(WINDOWS)
+    list(APPEND GAME_HEADER
+         proj.win32/main.h
+         proj.win32/resource.h
+         )
+    list(APPEND GAME_SOURCE
+         proj.win32/main.cpp
+         proj.win32/game.rc
+         ${common_res_files}
+         )
+elseif(APPLE)
+    if(IOS)
+        list(APPEND GAME_HEADER
+             proj.ios_mac/ios/AppController.h
+             proj.ios_mac/ios/RootViewController.h
+             )
+        set(APP_UI_RES
+            proj.ios_mac/ios/LaunchScreen.storyboard
+            proj.ios_mac/ios/LaunchScreenBackground.png
+            proj.ios_mac/ios/Images.xcassets
+            )
+        list(APPEND GAME_SOURCE
+             proj.ios_mac/ios/main.m
+             proj.ios_mac/ios/AppController.mm
+             proj.ios_mac/ios/RootViewController.mm
+             proj.ios_mac/ios/Prefix.pch
+             ${APP_UI_RES}
+             )
+    elseif(MACOSX)
+        set(APP_UI_RES
+            proj.ios_mac/mac/Icon.icns
+            proj.ios_mac/mac/Info.plist
+            )
+        list(APPEND GAME_SOURCE
+             proj.ios_mac/mac/main.cpp
+             proj.ios_mac/mac/Prefix.pch
+             ${APP_UI_RES}
+             )
+    endif()
+    list(APPEND GAME_SOURCE ${common_res_files})
+endif()
+
+# mark app complie info and libs info
+set(all_code_files
+    ${GAME_HEADER}
+    ${GAME_SOURCE}
+    )
+if(NOT ANDROID)
+    add_executable(${APP_NAME} ${all_code_files} "Classes/TitleScene.cpp" "Classes/StageSelectScene.cpp" "Classes/GameScene.cpp" "Classes/GameLayer.cpp" "Classes/Platform.cpp" "Classes/UILayer.cpp" "Classes/BGLayer.cpp" "Classes/Block.cpp" "Classes/Character.cpp" "Classes/Switch.cpp" "Classes/PauseLayer.cpp" "Classes/AudioManager.cpp" "Classes/Ladder.cpp" "Classes/GoalFlag.cpp" "Classes/StageLoader.cpp")
+else()
+    add_library(${APP_NAME} SHARED ${all_code_files})
+    add_subdirectory(${COCOS2DX_ROOT_PATH}/cocos/platform/android ${ENGINE_BINARY_PATH}/cocos/platform)
+    target_link_libraries(${APP_NAME} -Wl,--whole-archive cpp_android_spec -Wl,--no-whole-archive)
+endif()
+
+target_link_libraries(${APP_NAME} cocos2d)
+target_include_directories(${APP_NAME}
+        PRIVATE Classes
+        PRIVATE ${COCOS2DX_ROOT_PATH}/cocos/audio/include/
+)
+
+# mark app resources
+setup_cocos_app_config(${APP_NAME})
+if(APPLE)
+    set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")
+
+    if(MACOSX)
+        set_xcode_property(${APP_NAME} INFOPLIST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/proj.ios_mac/mac/Info.plist")
+    elseif(IOS)
+        set_xcode_property(${APP_NAME} INFOPLIST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/proj.ios_mac/ios/Info.plist")
+        set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon")
+    endif()
+
+    # For code-signing, set the DEVELOPMENT_TEAM:
+    #set_xcode_property(${APP_NAME} DEVELOPMENT_TEAM "GRLXXXX2K9")
+elseif(WINDOWS)
+    cocos_copy_target_dll(${APP_NAME})
+endif()
+
+if(LINUX OR WINDOWS)
+    cocos_get_resource_path(APP_RES_DIR ${APP_NAME})
+    cocos_copy_target_res(${APP_NAME} LINK_TO ${APP_RES_DIR} FOLDERS ${GAME_RES_FOLDER})
+endif()

--- a/Classes/GameLayer.h
+++ b/Classes/GameLayer.h
@@ -27,16 +27,15 @@ public:
     Character* _chara1;
     Character* _chara2;
 
-    Switch* _switch;
-    Block* _block;
+    std::vector<Switch*> _switch;
+    std::vector<Block*> _block;
+    std::vector<Ladder*> _ladder;
+    std::vector<GoalFlag*> _flag;
+
+    std::vector<kind_of> _on_switch_kind;
 
     Node* _stageRoot;
 
-    Ladder* _ladder;
-
-    GoalFlag* _flag;
-
-    /*EventKeyboard::KeyCode _currentKey = EventKeyboard::KeyCode::KEY_NONE;*/
     std::vector<EventKeyboard::KeyCode> _currentKey;
 
 private:

--- a/Classes/StageLoader.cpp
+++ b/Classes/StageLoader.cpp
@@ -57,7 +57,6 @@ void StageLoader::load(const std::string& jsonFile, Node* stageRoot)
             );
 
             auto block = Block::create(start, end, image);
-            block->setName("block");
             stageRoot->addChild(block);
         }
         else if (type == "Switch")
@@ -68,7 +67,6 @@ void StageLoader::load(const std::string& jsonFile, Node* stageRoot)
             );
 
             auto Switch = Switch::create(pos, image);
-            Switch->setName("switch");
             stageRoot->addChild(Switch);
         }
         else if (type == "Ladder")
@@ -83,7 +81,6 @@ void StageLoader::load(const std::string& jsonFile, Node* stageRoot)
             );
 
             auto ladder = Ladder::create(start, end, image);
-            ladder->setName("ladder");
             stageRoot->addChild(ladder);
         }
         else if (type == "GoalFlag")
@@ -94,7 +91,6 @@ void StageLoader::load(const std::string& jsonFile, Node* stageRoot)
             );
 
             auto flag = GoalFlag::create(pos, image);
-            flag->setName("flag");
             stageRoot->addChild(flag);
         }
     }

--- a/Classes/Switch.cpp
+++ b/Classes/Switch.cpp
@@ -78,6 +78,10 @@ void Switch::setState(State state) {
 
 }
 
+kind_of Switch::get_kind() {
+    return _kind;
+}
+
 Switch::~Switch() {
     CC_SAFE_RELEASE(_extraShape);
 }

--- a/Classes/Switch.h
+++ b/Classes/Switch.h
@@ -23,6 +23,7 @@ public:
     virtual bool init(cocos2d::Vec2, std::string);
 
     void setState(State);
+    kind_of get_kind();
 
 private:
     State _state = State::Off; //Switch凹み、ブロック透明状態がOn

--- a/Resources/stage_info/stage1.json
+++ b/Resources/stage_info/stage1.json
@@ -19,9 +19,25 @@
             "image": "Blocks/block_trans_red.png"
         },
         {
+            "type": "Block",
+            "start": [ 21, 2 ],
+            "end": [ 25, 7 ],
+            "image": "Blocks/block_trans_blue.png"
+        },
+        {
             "type": "Switch",
             "position": [ 14, 6 ],
             "image": "gimic/switch_red.png"
+        },
+        {
+            "type": "Switch",
+            "position": [ 15, 13 ],
+            "image": "gimic/switch_red.png"
+        },
+        {
+            "type": "Switch",
+            "position": [ 6, 4 ],
+            "image": "gimic/switch_blue.png"
         },
         {
             "type": "Ladder",
@@ -33,6 +49,11 @@
             "type": "GoalFlag",
             "position": [ 7, 4 ],
             "image": "gimic/flag_green.png"
+        },
+        {
+            "type": "GoalFlag",
+            "position": [ 13, 6 ],
+            "image": "gimic/flag_yellow.png"
         }
     ]
 }


### PR DESCRIPTION
・GameLayerのメンバである、_block、_switchなどをstd::vectorにすることで複数管理を実装
・複数管理の実装による課題点の修正
　・switch、blockクラスのseState()メソッドを呼ぶオブジェクトの場合分け
　・その場合分けに必要となった"何色のスイッチがOn状態になっているか"を表すvectorの追加とその処理 など